### PR TITLE
Added ability to specify sources via tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ You can specify the following options for displaying your itinerary:
 - `source`: The name of an obsidian source (or list of obsidian source) to gather data from; note that this must be surrounded in quotes (e.g. `"[[My Vacation Plans]]"`).  Defaults to events found in the same file the calendar is rendered in.  This field also accepts a path relative to your vault root instead of an obsian source name, but using an obsidian source name is recommended since such a name can be autocompleted via the editor.
 - `filter`: A list of filter expressions (see "Expressions" below) or a single filter expression to use for limiting which rows of the referenced CSV will be displayed. If unspecified, all events found in the selected sources will be included.
 - `debug`: Will cause some debugging information to be printed below your rendered itinerary.
+- `sourcetags`: A tag (or list of tags) of files from which to gather data; as with `source` this must be surrounded by quotes and include `#` (e.g. `"#events"`). This does not override `source`.
 
 In addition to the above, you can provide any options described here: https://fullcalendar.io/docs; particularly useful properties include:
 
@@ -219,7 +220,7 @@ filter:
 ```
 ~~~
 
-or 
+or
 
 ~~~
 ```itinerary

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, parseYaml, TAbstractFile, TFile } from "obsidian";
+import { Plugin, parseYaml, TAbstractFile, TFile, getAllTags } from "obsidian";
 
 import { parseEventSpec } from "./extractor";
 import { ItineraryRenderer, EventRenderer, renderErrorPre } from "./render";
@@ -155,6 +155,27 @@ export default class Itinerary extends Plugin {
             }
             if (!this.eventSources[sourcePath].includes(ctx.sourcePath)) {
               this.eventSources[sourcePath].push(ctx.sourcePath);
+            }
+          }
+
+          // Add any files with any of sourcetags to eventSources
+          if (tableSpec.sourcetags) {
+            const sTags = getArrayForArrayOrObject(tableSpec.sourcetags);
+            for (const file of allFiles) {
+              // Get all tags for file
+              const cache = this.app.metadataCache.getFileCache(file);
+              const fileTags: string[] = getAllTags(cache);
+              if (fileTags.filter(value => sTags.includes(value)).length > 0) {
+                // If the intersection between fileTags and sTags is non-empty,
+                // add the file path to resolvedEventSources
+                resolvedEventSources.push(file.path);
+                if (!this.eventSources[file.path]) {
+                  this.eventSources[file.path] = [];
+                }
+                if (!this.eventSources[file.path].includes(ctx.sourcePath)) {
+                  this.eventSources[file.path].push(ctx.sourcePath);
+                }
+              }
             }
           }
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -98,6 +98,7 @@ export class ItineraryRenderer extends MarkdownRenderChild {
         delete calendarProps.source;
         delete calendarProps.filter;
         delete calendarProps.debug;
+        delete calendarProps.sourcetags;
 
         this.calendar = new Calendar(this.container, {
           plugins: [dayGridPlugin, timeGridPlugin, listPlugin, luxonPlugin],

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type DocumentPath = string;
 
 export interface ItinerarySpec extends CalendarOptions {
   source?: string | string[];
+  sourcetags?: string | string[];
   filter?: string | string[];
   debug?: boolean;
 }


### PR DESCRIPTION
I implemented functionality to source events from any file with given tag(s). The change is a little hacky (check tags for every file in the vault), but works well enough.